### PR TITLE
Slideshow Block: use alternatives to 2 script dependencies

### DIFF
--- a/extensions/blocks/slideshow/view.js
+++ b/extensions/blocks/slideshow/view.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import { forEach } from 'lodash';
-import domReady from '@wordpress/dom-ready';
 import ResizeObserver from 'resize-observer-polyfill';
 
 /**
@@ -17,9 +15,9 @@ import {
 } from './swiper-callbacks';
 
 if ( typeof window !== 'undefined' ) {
-	domReady( function() {
+	document.addEventListener( 'DOMContentLoaded', function() {
 		const slideshowBlocks = document.getElementsByClassName( 'wp-block-jetpack-slideshow' );
-		forEach( slideshowBlocks, slideshowBlock => {
+		for ( const slideshowBlock of slideshowBlocks ) {
 			const { autoplay, delay, effect } = slideshowBlock.dataset;
 			const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 			const shouldAutoplay = autoplay && ! prefersReducedMotion;
@@ -67,6 +65,6 @@ if ( typeof window !== 'undefined' ) {
 						.querySelector( '.wp-block-jetpack-slideshow_container' )
 						.classList.add( 'wp-swiper-initialized' );
 				} );
-		} );
+		}
 	} );
 }

--- a/extensions/blocks/slideshow/view.js
+++ b/extensions/blocks/slideshow/view.js
@@ -15,7 +15,7 @@ import {
 } from './swiper-callbacks';
 
 if ( typeof window !== 'undefined' ) {
-	document.addEventListener( 'DOMContentLoaded', function() {
+	const initSlideshow = () => {
 		const slideshowBlocks = document.getElementsByClassName( 'wp-block-jetpack-slideshow' );
 		for ( const slideshowBlock of slideshowBlocks ) {
 			const { autoplay, delay, effect } = slideshowBlock.dataset;
@@ -66,5 +66,11 @@ if ( typeof window !== 'undefined' ) {
 						.classList.add( 'wp-swiper-initialized' );
 				} );
 		}
-	} );
+	};
+
+	if ( 'complete' === document.readyState || 'interactive' === document.readyState ) {
+		initSlideshow();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', initSlideshow );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes 2 dependencies of the Slideshow Block's front-end script
* These weren't render-blocking, being in the footer. But this should slightly improve performance for this block, and perhaps other scripts in the footer.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This changes an existing feature.

#### Testing instructions:
1. Create a new post, and add a Slideshow Block
2. Select several images for the block
3. Click 'Preview' to go to the front-end
4. Expected: it should be possible to click through all of the images:

![swipe-slide](https://user-images.githubusercontent.com/4063887/74908148-b40ba900-537a-11ea-9d44-f39c3f85b7db.gif)

#### Proposed changelog entry for your changes:
* Use alternatives to 2 scripts in the Slideshow Block.
